### PR TITLE
Add more robust logic for importing pydantic V2's V1 compatibility pa…

### DIFF
--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -29,7 +29,18 @@ from typing import (
 import arrow
 import pint
 import pytz
-from pydantic.v1 import BaseModel
+
+
+from stravalib.pydantic_version import pydantic_major_version
+
+if pydantic_major_version == '2':
+    try:
+        from pydantic.v1 import BaseModel
+    except ImportError:
+        raise ImportError("pydantic.v1 module not found. You might be using an unsupported version of Pydantic.")
+elif pydantic_major_version == '1':
+    from pydantic import BaseModel
+
 from requests import Session
 
 from stravalib import exc, model, strava_model, unithelper

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -27,8 +27,17 @@ from typing import (
     get_args,
 )
 
-from pydantic.v1 import BaseModel, Field, root_validator, validator
-from pydantic.v1.datetime_parse import parse_datetime
+from stravalib.pydantic_version import pydantic_major_version
+if pydantic_major_version == '2':
+    try:
+        from pydantic.v1 import BaseModel, Field, root_validator, validator
+        from pydantic.v1.datetime_parse import parse_datetime
+    except ImportError:
+        raise ImportError("pydantic.v1 module not found. You might be using an unsupported version of Pydantic.")
+elif pydantic_major_version == '1':
+    from pydantic import BaseModel, Field, root_validator, validator
+    from pydantic.datetime_parse import parse_datetime
+
 from typing_extensions import Self
 
 from stravalib import exc, strava_model

--- a/src/stravalib/pydantic_version.py
+++ b/src/stravalib/pydantic_version.py
@@ -1,0 +1,3 @@
+from pydantic import version
+
+pydantic_major_version = version.VERSION.split(".")[0]

--- a/src/stravalib/strava_model.py
+++ b/src/stravalib/strava_model.py
@@ -6,7 +6,14 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal, Optional
 
-from pydantic.v1 import BaseModel, Field
+from stravalib.pydantic_version import pydantic_major_version
+if pydantic_major_version == '2':
+    try:
+        from pydantic.v1 import BaseModel, Field
+    except ImportError:
+        raise ImportError("pydantic.v1 module not found. You might be using an unsupported version of Pydantic.")
+elif pydantic_major_version == '1':
+    from pydantic import BaseModel, Field
 
 
 class ActivityTotal(BaseModel):

--- a/src/stravalib/tests/unit/test_model.py
+++ b/src/stravalib/tests/unit/test_model.py
@@ -4,7 +4,15 @@ from typing import List, Optional
 import pint
 import pytest
 import pytz
-from pydantic.v1 import BaseModel
+
+from stravalib.pydantic_version import pydantic_major_version
+if pydantic_major_version == '2':
+    try:
+        from pydantic.v1 import BaseModel
+    except ImportError:
+        raise ImportError("pydantic.v1 module not found. You might be using an unsupported version of Pydantic.")
+elif pydantic_major_version == '1':
+    from pydantic import BaseModel
 
 from stravalib import model
 from stravalib import unithelper as uh


### PR DESCRIPTION
## Description

Previous pull request #456 didn't have a robust import logic. For example, we would see failures when users using Pydantic V1 tried to import `pydantic.v1`. This PR adds in guards to account for that.

## Type of change

Select the statement best describes this pull request.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [X] This change doesn't require tests

## Did you include your contribution to the change log?

- [ ] Yes, `changelog.md` is up-to-date.

_If you are having a hard time getting the tests to run correctly feel free to
ping one of the maintainers here!_

<!---
If you are a stravalib maintainer submitting a PR in preparation for a new release
you can use the pull request release template:

[https://github.com/stravalib/stravalib/compare/main...branch-name-here?template=release-pull-request-template.md](https://github.com/stravalib/stravalib/compare/main...branch-name-here?template=release-pull-request-template.md). Be sure to modify
the text "branch-name-here" in the above url to apply the release template.
-->
